### PR TITLE
Added noescape macro for columnsSummary

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -467,7 +467,7 @@
 		{var $td = $column->getElementForRender('td', $key)}
 
 		{$td->startTag()|noescape}
-			{$columnsSummary->render($key)}
+			{$columnsSummary->render($key)|noescape}
 		{$td->endTag()|noescape}
 	{/foreach}
 


### PR DESCRIPTION
Because for rendering I am using setRenderer() callback with my own HTML format